### PR TITLE
Hide clojure code, rendering only markdown

### DIFF
--- a/src/cashcloj/core.clj
+++ b/src/cashcloj/core.clj
@@ -9,6 +9,7 @@
             [aerial.hanami.templates :as ht]))
 
 
+^{:kindly/hide-code true}
 (kind/md ["
 # [Scicloj](https://scicloj.github.io/) explorations part 1 | NASDAQ & Cryptocurrency timeseries
 
@@ -47,20 +48,20 @@ easy to operate on.
 In this example I just select a few columns and keep the top 50
 "])
 
-(-> "data/nasdaq-instrument-list.csv"
-  (tc/dataset {:key-fn (comp keyword to-kebab-case)})
-  (tc/select-columns [:symbol :name])
-  (tc/head 50))
-
 (defn to-kebab-case [s]
   (-> s
-    (str/lower-case)
-    (str/replace #" " "-")))
+      (str/lower-case)
+      (str/replace #" " "-")))
 
 (-> "data/nasdaq-instrument-list.csv"
-  (tc/dataset {:key-fn (comp keyword to-kebab-case)})
-  (tc/order-by :volume)
-  (tc/head 10))
+    (tc/dataset {:key-fn (comp keyword to-kebab-case)})
+    (tc/select-columns [:symbol :name])
+    (tc/head 50))
+
+(-> "data/nasdaq-instrument-list.csv"
+    (tc/dataset {:key-fn (comp keyword to-kebab-case)})
+    (tc/order-by :volume)
+    (tc/head 10))
 
 (def nasdaq-instruments
   (-> "data/nasdaq-instrument-list.csv"


### PR DESCRIPTION
Clay renders all code by default, if you don’t want to see the code block that generates the markdown text you can either convert it to markdown-formatted comments, or add the `^{:kindly/hide-code true}` metadata to the code block that you want to hide. This is an example of hiding the code block. It also moves the definition of `to-kebab-case` to above its first use (functions need to be defined before they are used in Clojure).