### PR TITLE
Render comments as markdown

### DIFF
--- a/src/cashcloj/core.clj
+++ b/src/cashcloj/core.clj
@@ -9,34 +9,33 @@
             [aerial.hanami.templates :as ht]))
 
 
-(kind/md ["
-# [Scicloj](https://scicloj.github.io/) explorations part 1 | NASDAQ & Cryptocurrency timeseries
+;; # [Scicloj](https://scicloj.github.io/) explorations part 1 | NASDAQ & Cryptocurrency timeseries
 
-This is my first exploration in the world of data science under the hand of Scicloj.
-I decided to give this stack a try due to its [interactive programming](https://docs.cider.mx/cider/usage/interactive_programming.html) capacities.
-This concept was introduced to me during a [London Clojurians](https://londonclojurians.org/) talk [\"From data to insights: Clojure for data deep dive\"](https://www.youtube.com/watch?v=eUFf3-og_-Y).
+;; This is my first exploration in the world of data science under the hand of Scicloj.
+;; I decided to give this stack a try due to its [interactive programming](https://docs.cider.mx/cider/usage/interactive_programming.html) capacities.
+;; This concept was introduced to me during a [London Clojurians](https://londonclojurians.org/) talk [\"From data to insights: Clojure for data deep dive\"](https://www.youtube.com/watch?v=eUFf3-og_-Y).
 
-This file you are looking at is rendered using [Clay](https://github.com/scicloj/clay).
+;; This file you are looking at is rendered using [Clay](https://github.com/scicloj/clay).
 
-**What's the stack?**
+;; **What's the stack?**
 
-- [Spacemacs](https://www.spacemacs.org/) for my text editor as it comes with plugins for [Clay](https://github.com/scicloj/clay) & [Cider](https://github.com/clojure-emacs/cider)
-- [Clojure](https://clojure.org/) A dynamically typed lisp dialect that calls the JVM home
-- [Tablecloth](https://scicloj.github.io/tablecloth) a `dataframe` like manipulation library. Similar to Pandas
-- [Clay](https://github.com/scicloj/clay) for data visualizations in a dynamic fashion
+;; - [Spacemacs](https://www.spacemacs.org/) for my text editor as it comes with plugins for [Clay](https://github.com/scicloj/clay) & [Cider](https://github.com/clojure-emacs/cider)
+;; - [Clojure](https://clojure.org/) A dynamically typed lisp dialect that calls the JVM home
+;; - [Tablecloth](https://scicloj.github.io/tablecloth) a `dataframe` like manipulation library. Similar to Pandas
+;; - [Clay](https://github.com/scicloj/clay) for data visualizations in a dynamic fashion
 
-**What'll be doing**
+;; **What'll be doing**
 
-I downloaded all the instruments from [NASDAQ](https://www.nasdaq.com/) and the top 250 cryptocurrencies from [Binance](https://www.binance.com/). We are going to
-go ahead and explore these datasets.
+;; I downloaded all the instruments from [NASDAQ](https://www.nasdaq.com/) and the top 250 cryptocurrencies from [Binance](https://www.binance.com/). We are going to
+;; go ahead and explore these datasets.
 
-For the purposes of this first exploration I will keep things extremely simple. We'll visualise the data as a table, perform simple transformations & plot it onto a few simple charts.
+;; For the purposes of this first exploration I will keep things extremely simple. We'll visualise the data as a table, perform simple transformations & plot it onto a few simple charts.
 
-**How I'm doing it**
+;; **How I'm doing it**
 
-With some help & documentation I have set up my spacemacs so I can cast functions onto either a buffer or Clay.
-This way I can immediately get feedback on each single function I evaluate.
-"])
+;; With some help & documentation I have set up my spacemacs so I can cast functions onto either a buffer or Clay.
+;; This way I can immediately get feedback on each single function I evaluate.
+
 
 (kind/md ["
 ## Reading a dataset
@@ -47,15 +46,15 @@ easy to operate on.
 In this example I just select a few columns and keep the top 50
 "])
 
+(defn to-kebab-case [s]
+  (-> s
+      (str/lower-case)
+      (str/replace #" " "-")))
+
 (-> "data/nasdaq-instrument-list.csv"
   (tc/dataset {:key-fn (comp keyword to-kebab-case)})
   (tc/select-columns [:symbol :name])
   (tc/head 50))
-
-(defn to-kebab-case [s]
-  (-> s
-    (str/lower-case)
-    (str/replace #" " "-")))
 
 (-> "data/nasdaq-instrument-list.csv"
   (tc/dataset {:key-fn (comp keyword to-kebab-case)})
@@ -94,4 +93,3 @@ In this example I just select a few columns and keep the top 50
                                :WIDTH 1000
                                :COLOR {:field :highly-volatile}
                                }))
-


### PR DESCRIPTION
Clay renders all code by default, if you don’t want to see the code block that generates the markdown text you can either convert it to markdown-formatted comments, or add the ^{:kindly/hide-code true} metadata to the code block that you want to hide. This is an example of writing markdown in comments instead of a `kind/md` block. It also moves the definition of to-kebab-case to above its first use (functions need to be defined before they are used in Clojure). This is my preferred way to render markdown from Clojure notebooks, but both are options are completely correct.